### PR TITLE
Remember used user_data startup JSON file path

### DIFF
--- a/Utilities/openLuup_reload
+++ b/Utilities/openLuup_reload
@@ -8,5 +8,5 @@ lua5.1 openLuup/init.lua $1
 
 while [ $? -eq 42 ]
 do
-   lua5.1 openLuup/init.lua
+   lua5.1 openLuup/init.lua $1
 done

--- a/Utilities/openLuup_reload.bat
+++ b/Utilities/openLuup_reload.bat
@@ -9,7 +9,7 @@ CD %CURRENT_PATH%
 
 :loop
 IF NOT %ERRORLEVEL% == 42 GOTO exit
-"%LUA_DEV%\lua" openLuup\init.lua
+"%LUA_DEV%\lua" openLuup\init.lua %1
 GOTO loop
 
 :exit

--- a/openLuup/init.lua
+++ b/openLuup/init.lua
@@ -1,6 +1,6 @@
 local ABOUT = {
   NAME          = "openLuup.init",
-  VERSION       = "2018.03.21",
+  VERSION       = "2018.08.07",
   DESCRIPTION   = "initialize Luup engine with user_data, run startup code, start scheduler",
   AUTHOR        = "@akbooer",
   COPYRIGHT     = "(c) 2013-2018 AKBooer",
@@ -45,6 +45,7 @@ local ABOUT = {
 -- 2018.02.19  add current directory to startup log
 -- 2018.02.25  add ip address to openLuup.Server
 -- 2018.03.09  add SMTP server
+-- 2018.08.07  update path to user supplied user_data.json in userdata
 
 
 local loader = require "openLuup.loader" -- keep this first... it prototypes the global environment
@@ -207,6 +208,9 @@ do -- STARTUP
       local json_code = code: match "^%s*{"               -- what sort of code is this?
       if json_code then 
         ok = userdata.load (code)
+        if ok then
+            luup.attr_set("openLuup.UserData.Name", init)
+        end
         code = userdata.attributes ["StartupCode"] or ''  -- substitute the Startup Lua
       end
       compile_and_run (code, "_openLuup_STARTUP_")        -- the given file or the code in user_data

--- a/openLuup/luup.lua
+++ b/openLuup/luup.lua
@@ -1,6 +1,6 @@
 local ABOUT = {
   NAME          = "openLuup.luup",
-  VERSION       = "2018.03.22",
+  VERSION       = "2018.08.07",
   DESCRIPTION   = "emulation of luup.xxx(...) calls",
   AUTHOR        = "@akbooer",
   COPYRIGHT     = "(c) 2013-2018 AKBooer",
@@ -51,6 +51,7 @@ local ABOUT = {
 -- 2018.02.10  ensure valid error in luup.call_action() even if missing parameters
 -- 2018.03.08  extend register_handler to work with email (local SMTP server)
 -- 2018.03.22  use renamed io.luupio module, use logs.register()
+-- 2018.08.07  use user_data.json as configure in userdata to save userdata to before reload
 
 
 local logs          = require "openLuup.logs"
@@ -679,7 +680,8 @@ local function reload (exit_status)
   end
   
   _log ("saving user_data", "luup.reload") 
-  local ok, msg = userdata.save (luup)
+  local name = (attr_get "openLuup.UserData.Name") or "user_data.json"
+  local ok, msg = userdata.save (luup, name)
   assert (ok, msg or "error writing user_data")
   
   local shutdown = attr_get "ShutdownCode"


### PR DESCRIPTION
openLuup allows loading of userdata from another file than the default user_data.json located in the installation folder by specifying the path as a command line argument to init.lua. This feature is advertised in e.g. the openLuup_reload scripts.

I encountered two bugs that prevent fully succesful usage of this feature:
- the regular checkpoint that updating the user_data.json file is never updated to the file provided on the command line, but continues to use the default user_data.json
- the json file specified as argument of init.lua is not stored in the userdata (the configuration objec remains `  "UserData":{
    "Checkpoint":60,
    "Name":"user_data.json"
  }`

I encountered these issues while creating a dockerized setup for openLuup. With the patch in this pull request, these problems are resolved.

The docker image I created is available at https://hub.docker.com/r/vwout/openluup/